### PR TITLE
Ensure runtime session sharing and relay final outputs

### DIFF
--- a/app/api/llm/route.ts
+++ b/app/api/llm/route.ts
@@ -1,4 +1,4 @@
-export const runtime = "edge";
+export const runtime = "nodejs";
 
 import { chat, calcTool, weatherTool } from "@/lib/llm";
 import { enqueue } from "@/lib/runtime";

--- a/app/api/runs/route.ts
+++ b/app/api/runs/route.ts
@@ -1,5 +1,5 @@
 // app/api/runs/route.ts
-export const runtime = 'edge';
+export const runtime = 'nodejs';
 import { executeGraph } from '@/lib/runtime';
 
 export async function POST(req: Request) {

--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -1,4 +1,4 @@
-export const runtime = 'edge'
+export const runtime = 'nodejs'
 import { createSession } from '@/lib/runtime'
 
 export async function POST() {

--- a/app/api/stream/route.ts
+++ b/app/api/stream/route.ts
@@ -1,4 +1,4 @@
-export const runtime = 'edge';
+export const runtime = 'nodejs';
 
 import { dequeueBatch } from '@/lib/runtime';
 


### PR DESCRIPTION
## Summary
- Run all API routes on the Node runtime so they share session state
- Forward upstream answers and results into connected Output nodes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c08a6db5c832094862663d1503dc8